### PR TITLE
Dockerize moneysocket

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -1,0 +1,41 @@
+name: ci
+
+on:
+  push:
+    branches: main
+
+jobs:
+  docker-build:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v2
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      -
+        name: Cache Docker layers
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+      -
+        name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.GH_USERNAME }}
+          password: ${{ secrets.GH_TOKEN }}
+      -
+        name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./contrib/Dockerfile
+          push: true
+          tags: ghcr.io/moneysocket/py-moneysocket:latest
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache

--- a/contrib/Dockerfile
+++ b/contrib/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:3.8
+
+RUN apt update  && \
+  apt install libsecp256k1-dev -y
+
+COPY ./ /moneysocket
+
+WORKDIR /moneysocket
+
+RUN pip install -e .


### PR DESCRIPTION
As discussed in telegram, this adds a `Dockerfile` in the `contrib/` folder and a github action to build it. I can't show a demo on moneysocket since the secrets aren't set. But I have setup a demo on my account in jakesyl/py-moneysocket#1 (see working action [here](https://github.com/jakesyl/py-moneysocket/runs/1723347339)). The only difference here is branch has been changed to `main` and tag has been changed to the moneysocket organization.

As an aside, my main motivation for dockerizing is this is kind of pain to build on a mac. Namely the `secp256k1` module on mac builds without `--enable-module-recovery` by default (see: ethereum/pyethereum#392).

To make this work, you'll have to: 

 - add the `GH_USERNAME` and `GH_TOKEN` [secrets to this account](https://docs.github.com/en/actions/reference/encrypted-secrets#creating-encrypted-secrets-for-an-organization)
 - [enable improved container support](https://docs.github.com/en/packages/guides/enabling-improved-container-support#:~:text=On%20the%20left%20side%20of,container%20support%22%20and%20click%20Save.) for the organization (as per https://github.com/docker/build-push-action/issues/205#issuecomment-728894085)